### PR TITLE
Explicitly add `-analyzed` flag to analyze & export

### DIFF
--- a/cnb.yaml
+++ b/cnb.yaml
@@ -73,6 +73,7 @@ spec:
     - "-layers=/layers"
     - "-helpers=${USE_CRED_HELPERS}"
     - "-group=/layers/group.toml"
+    - "-analyzed=/layers/analyzed.toml"
     - "${IMAGE}"
     imagePullPolicy: Always
     volumeMounts:
@@ -100,6 +101,7 @@ spec:
     - "-helpers=${USE_CRED_HELPERS}"
     - "-app=/workspace"
     - "-group=/layers/group.toml"
+    - "-analyzed=/layers/analyzed.toml"
     - "${IMAGE}"
     imagePullPolicy: Always
     volumeMounts:


### PR DESCRIPTION
Without this flag export is unable to reuse layers.

This results in errors on rebuilds like:
`Error: failed to export: cannot reuse `io.buildpack.java`, previous image has no metadata for layer `io.buildpack.java`